### PR TITLE
Package create scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "scripts": {
         "start": "bash scripts/create-scratch-org.sh",
         "bootstrap-pkg": "bash scripts/bootstrap-package.sh",
-        "install-test-pkg": "bash scripts/create-package-version.sh",
+        "test-pkg": "bash scripts/create-package-version.sh",
+        "prep-release": "bash scripts/prep-release-package.sh",
         "setup": "npm run setup-auth-devhub",
         "setup-auth-devhub": "bash scripts/setup-auth-devhub.sh",
         "setup-auth-prod": "bash scripts/setup-auth-prod.sh",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     },
     "scripts": {
         "start": "bash scripts/create-scratch-org.sh",
+        "bootstrap-pkg": "bash scripts/bootstrap-package.sh",
+        "install-test-pkg": "bash scripts/create-package-version.sh",
         "setup": "npm run setup-auth-devhub",
         "setup-auth-devhub": "bash scripts/setup-auth-devhub.sh",
         "setup-auth-prod": "bash scripts/setup-auth-prod.sh",

--- a/scripts/boostrap-package.sh
+++ b/scripts/boostrap-package.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+
+# This script creates the starting directory structure for a new package and optionally runs SFDX package:create
+# If choosing to generate the package when running this script, it is expected the developer:
+# - Setup the Namespace and specified the "namespace" key in sfdx-project.json
+# 2GP workflow documentation see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_dev2gp_workflow.htm
+
+set -e
+
+# Get the package name and the package directory
+read -p "Enter new package name: " PKG_NAME
+
+if grep "\"$PKG_NAME\"," sfdx-project.json; then
+    echo 'This package has already been created! Exiting ... '
+    exit 1
+fi
+
+# Guess the package directory from entered name
+PKG_PATH=$(echo "$PKG_NAME"\
+    | sed -E 's/[[:blank:]]+([a-z0-9])/\U\1/gi'\
+    | sed -E 's/_([A-Z0-9])/\U\1/gi'\
+    | sed -E 's/-([A-Z0-9])/\U\1/gi'\
+    | sed -E 's/^([A-Z0-9])/\l\1/')
+
+read -p "Is this the desired package path: ${PKG_PATH}? y/n " ACCEPT_PATH
+
+# Ensure package folder name and existence
+if [[ "$ACCEPT_PATH" != 'y' ]] ; then
+    read -p "Enter directory path to this package (relative to project root): " PKG_PATH
+fi
+
+# Generate folder structure for new module
+mkdir "$PKG_PATH"
+mkdir "${PKG_PATH}/main"
+mkdir "${PKG_PATH}/main/default"
+
+echo "Generated directories for new module ${PKG_NAME}."
+echo "You can run SFDX package create step now."
+echo "NOTE: Namespace must already be prepared and entered in sfdx-project.json. This can also be done later when creating test package versions."
+read -p "Create package now? y/n " RUN_CREATE
+
+# Check if package has already been created; If not, create package now
+if [[ "$RUN_CREATE" == 'y' ]]; then
+    echo "Creating the package ${PKG_NAME}."
+    read  -p "Is this a Managed package (and Namespace is prepared)? y/n " PKG_TYPE
+    test "$PKG_TYPE" == 'y' && PKG_TYPE='Managed' || PKG_TYPE='Unlocked'
+    sfdx force:package:create --name "$PKG_NAME" --packagetype "$PKG_TYPE" --path "$PKG_PATH"
+fi
+
+echo "Package bootstrapped! May the Flow be with you!"
+
+exit

--- a/scripts/create-package-version.sh
+++ b/scripts/create-package-version.sh
@@ -45,9 +45,12 @@ fi
 # TODO: A step for updating the newly-generated package's configuration fields can go here (see package.json)
 #
 
-# Optionally skip validation for rapid development; This will become mandatory before package promotion however
+# Optionally skip validation for rapid development
+# NOTE: When readying for release, a validated version is mandatory for package promotion
 read -p "Temporarily skip validation in package version creation? " SKIP_VALIDATION
 
+# Create package version
+# NOTE: Version ID based on convention noted in package:version:report cmd doc: "ID (starts with 04t)"
 if [ "$SKIP_VALIDATION" == 'y' ]; then
     echo "Creating new version of package ${PKG_NAME} ... skipping validation ..."
     PACKAGE_VER_ID=$(sfdx force:package:version:create --package "$PKG_NAME" --installationkeybypass --wait 15 --skipvalidation \

--- a/scripts/create-package-version.sh
+++ b/scripts/create-package-version.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -l
+
+# This script uses SFDX to generate a new version of a package, creating the package if needed.
+# Package versions are what actually get installed into Orgs.
+# Prior to running this script and generating the package, it is expected the developer:
+# - Verified that all package components are in the project directory where you want to create the package
+# - Setup the Namespace and specified the "namespace" key in sfdx-project.json
+# 2GP workflow documentation see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_dev2gp_workflow.htm
+
+set -e
+
+# Get the package name and the package directory
+read -p "Enter package name: " PKG_NAME
+
+# Guess the package directory from entered name
+PKG_PATH=$(echo "$PKG_NAME"\
+    | sed -E 's/[[:blank:]]+([a-z0-9])/\U\1/gi'\
+    | sed -E 's/_([A-Z0-9])/\U\1/gi'\
+    | sed -E 's/-([A-Z0-9])/\U\1/gi'\
+    | sed -E 's/^([A-Z0-9])/\l\1/')
+
+read -p "Is this the correct package path: ${PKG_PATH}? y/n " ACCEPT_PATH
+
+# Ensure package folder name and existence
+if [[ "$ACCEPT_PATH" != 'y' ]] ; then
+    read -p "Enter directory path to this package (relative to project root): " PKG_PATH
+fi
+
+if [[ ! -d "$PKG_PATH" ]]; then
+    echo "Package directory does not exist!"
+    exit 1
+fi
+
+# Check if package has already been created; If not, create package now
+if grep "\"$PKG_NAME\"," sfdx-project.json; then
+    echo 'This package has already been created! Moving on to versioning ... '
+else
+    echo "Creating the package ${PKG_NAME}."
+    read  -p "Is this a Managed package (and Namespace is prepared)? y/n " PKG_TYPE
+    test "$PKG_TYPE" == 'y' && PKG_TYPE='Managed' || PKG_TYPE='Unlocked'
+    sfdx force:package:create --name "$PKG_NAME" --packagetype "$PKG_TYPE" --path "$PKG_PATH"
+fi
+
+#
+# TODO: A step for updating the newly-generated package's configuration fields can go here (see package.json)
+#
+
+# Optionally skip validation for rapid development; This will become mandatory before package promotion however
+read -p "Temporarily skip validation in package version creation? " SKIP_VALIDATION
+
+if [ "$SKIP_VALIDATION" == 'y' ]; then
+    echo "Creating new version of package ${PKG_NAME} ... skipping validation ..."
+    PACKAGE_VER_ID=$(sfdx force:package:version:create --package "$PKG_NAME" --installationkeybypass --wait 15 --skipvalidation \
+    | grep login.salesforce.com \
+    | sed -E 's/^.*(04t[[:alnum:]]*)$/\1/')
+else
+    echo "Creating new version of package ${PKG_NAME} ..."
+    PACKAGE_VER_ID=$(sfdx force:package:version:create --package "$PKG_NAME" --installationkeybypass --wait 15 \
+    | grep login.salesforce.com \
+    | sed -E 's/^.*(04t[[:alnum:]]*)$/\1/')
+fi
+
+echo "Successfully generated package with version ID: ${PACKAGE_VER_ID}"
+
+# Optionally install this new package version into a test scratch org for immediate testing
+while true; do
+    read -p "Continue with test org installation? y/n " TEST_INSTALL
+    case "$TEST_INSTALL" in
+        [Yy]* ) source scripts/install-test-package.sh;;
+        [Nn]* ) break;;
+        * ) echo "y/n.";;
+    esac
+done

--- a/scripts/install-test-package.sh
+++ b/scripts/install-test-package.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -l
+
+# This script attempts to install a freshly created package version into a temporary test scratch org.
+# Requires that a Package version ID was successfully generated in prior step.
+
+set -e
+
+TEST_ORG="PackageTestOrg"
+
+if [ -z "$PACKAGE_VER_ID" ]; then
+    echo "No package version specified for install! Exiting ... "
+    exit 1
+fi
+
+echo "Install package to temporary scratch org for testing with version ID: ${PACKAGE_VER_ID} ... "
+
+# Check if "PackageTestOrg" already exists, delete if it does
+if sfdx force:org:list | grep "$TEST_ORG"; then
+    echo "Pre-existing test scratch org detected! Deleting ..."
+    sfdx force:org:delete -u "$TEST_ORG" -p
+fi
+
+# Generate a fresh scratch org to install the package
+sfdx force:org:create --definitionfile config/project-scratch-def.json --setalias "$TEST_ORG"
+
+# Install the package and open the new scratch org for testing
+sfdx force:package:install --package "$PACKAGE_VER_ID" --targetusername "$TEST_ORG"
+
+unset PACKAGE_VER_ID
+
+echo ""
+echo "Opening scratch org for testing, may the Flow be with you!"
+echo ""
+sleep 3
+sfdx force:org:open --targetusername "$TEST_ORG"
+
+exit

--- a/scripts/prep-release-package.sh
+++ b/scripts/prep-release-package.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -l
+
+# This script will create a PROMOTED package version for tentative release.
+# Only released package versions can be listed on AppExchange and installed in customer orgs.
+# Prior to running the script, it is expected that the package has been fully-tested (incl. unit tests and adequate code coverage) and is release-ready.
+
+set -e
+
+# Get the package name and the package directory
+read -p "Enter package name: " PKG_NAME
+
+if ! grep "\"$PKG_NAME\"," sfdx-project.json; then
+    echo 'Specified package does not exist! Double check the package name. Exiting ... '
+    exit
+fi
+
+# Check if this is a new version release
+# TODO: redo version check flow to directly modify version info based on prompt instead of requiring manual modifcation before running script
+echo "Package versions with same MAJOR.MINOR.PATCH can only be released once!"
+read -p "Is this a new version release and have you updated version information in the package configuration file? y/n: " NEW_VER
+
+if [[ "$NEW_VER" != 'y' ]] ; then
+    echo "Ensure you have updated the version number in the package configuration file (sfdx-project.json) then rerun this script."
+    exit
+fi
+
+# Create a new package version for promotion
+echo "Create package version for promotion..."
+sfdx force:package:version:create --package "$PKG_NAME" --installationkeybypass --codecoverage --wait 15
+
+if [ "$?" = "1" ]; then
+	echo "" && echo "ERROR: Problem creating release-ready package version! Ensure passing unit tests and code coverage! Exiting ..."
+    exit 1
+fi
+
+PKG_VER_ID=$(grep "Test Package 1" sfdx-project.json | tail -1 | sed -E 's/^.*"(04t[[:alnum:]]*)"$/\1/')
+
+# Promote package
+echo "Promote package ${PKG_NAME} for release ..."
+sfdx force:package:version:promote --package "$PKG_VER_ID" --noprompt
+echo "Package version has been promoted!"
+
+# TODO: Specify a specific pre-release (non-scratch) org for testing?
+# Generate a fresh test scratch org to install the package
+echo "Install promoted package to temporary scratch org for final testing ... "
+if sfdx force:org:list | grep 'PackageTestOrg'; then
+    echo "Deleting pre-existing test scratch org ..."
+    sfdx force:org:delete -u PackageTestOrg -p
+fi
+sfdx force:org:create --definitionfile config/project-scratch-def.json --setalias PackageTestOrg
+echo "Test scratch org created."
+
+echo "Preparing to test install PROMOTED package ${PKG_NAME} ... "
+sfdx force:package:install --package "$PKG_VER_ID" --targetusername PackageTestOrg --noprompt --wait -1
+
+if [ "$?" = "1" ]
+then
+	echo "" && echo "ERROR: Problem installing test package!"
+	exit
+else
+    echo "Package install successful!"
+fi
+
+unset PKG_VER_ID
+
+echo ""
+echo "Opening scratch org for final testing before official release!"
+echo ""
+sleep 3
+sfdx force:org:open --targetusername PackageTestOrg
+
+exit


### PR DESCRIPTION
Add several scripts to run through the 2GP workflow from initial package creation to version release.

Scripts:

- `bootstrap-package.sh`: Begin development on a new package; This script will run the appropriate sfdx command and also create a new "empty" directory for the module at project root level. Files for the new package would then fall under this new sub-folder.

- `create-package-version.sh`: Used to generate new *build* versions of an in-development package. The subsequent new package build can then be manually installed into a test org **or** there is an option to continue to automated installation into a test scratch org.

- `install-test-package.sh`: Generates a temporary scratch org for testing and installs the most recently created package build.

- `prep-release-package.sh`: Runs through the pre-release flow to ready a package for new version release, including automatic installation into one final test org.
NOTES: 1) only one release per MAJOR.MINOR.PATCH version of a package is allowed, 2) the script in its current form *assumes* that the dev has updated package config in `sfdx-project.json` with the new version information (see `"versionNumber"` property). 